### PR TITLE
upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ matrix:
   include:
 
     - language: scala
-      scala: 2.12.3
+      scala: 2.12.4
       jdk: oraclejdk8
       services:
         - docker
@@ -18,7 +18,7 @@ matrix:
         - sbt ++$TRAVIS_SCALA_VERSION test
 
     - language: scala
-      scala: 2.11.11
+      scala: 2.11.12
       jdk: oraclejdk8
       services:
         - docker

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
-scalaVersion in ThisBuild := "2.12.3"
-crossScalaVersions := Seq("2.12.3", "2.11.11")
+scalaVersion in ThisBuild := "2.12.4"
+crossScalaVersions := Seq("2.12.4", "2.11.12")
 publishArtifact := false
 
 // license settings
@@ -13,17 +13,16 @@ val dockerImageVersion = taskKey[String]("the version for docker image of schema
 
 // The versions for dependency libraries
 val avroVersion = "1.8.2"
-val circeVersion = "0.8.0"
-val ficusVersion = "1.4.1"
-val finagleVersion = "6.45.0"
-val finchVersion = "0.15.1"
-val twitterServerVersion = "1.30.0"
+val circeVersion = "0.9.1"
+val ficusVersion = "1.4.3"
+val twitterVersion = "18.2.0"
+val finchVersion = "0.17.0"
 
 // The versions for test dependency libraries
-val dockerComposeRuleVersion = "0.16.0"
-val junitVersion = "4.10"
-val scalaTestVersion = "3.0.0"
-val slf4jVersion = "1.7.21"
+val dockerComposeRuleVersion = "0.33.0"
+val junitVersion = "4.12"
+val scalaTestVersion = "3.0.5"
+val slf4jVersion = "1.7.25"
 
 
 // make test execution sequential across projects to support docker-compose-rule integration testing
@@ -33,6 +32,7 @@ concurrentRestrictions in ThisBuild := Seq(
   Tags.limit(Tags.Untagged, 1)
 )
 
+enablePlugins(GitVersioning)
 
 lazy val commonSettings = Seq(
   addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
@@ -49,9 +49,8 @@ lazy val commonSettings = Seq(
   publishArtifact in Test := false,
   publishMavenStyle := true,
   resolvers ++= Seq(
-    "Palantir Repository" at "https://dl.bintray.com/palantir/releases",
-    "twttr" at "http://maven.twttr.com",
-    Resolver.sonatypeRepo("releases")
+    Resolver.sonatypeRepo("releases"),
+    Resolver.bintrayRepo("palantir", "releases")
   ),
   run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run)),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
@@ -72,7 +71,6 @@ lazy val core = (project in file("core")).
       "io.circe" %% "circe-generic-extras" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
       "org.apache.avro" % "avro" % avroVersion,
-      "com.palantir.docker.compose" % "docker-compose-rule" % dockerComposeRuleVersion % Test,
       "junit" % "junit" % junitVersion % Test,
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
       "org.slf4j" % "slf4j-api" % slf4jVersion % Test,
@@ -91,12 +89,12 @@ lazy val server = (project in file("server")).
     libraryDependencies ++= Seq(
       "com.github.finagle" %% "finch-core" % finchVersion,
       "com.github.finagle" %% "finch-circe" % finchVersion,
-      "com.twitter" %% "finagle-core" % finagleVersion,
-      "com.twitter" %% "finagle-mysql" % finagleVersion,
-      "com.twitter" %% "finagle-stats" % finagleVersion,
-      "com.twitter" %% "twitter-server" % twitterServerVersion,
+      "com.twitter" %% "finagle-core" % twitterVersion,
+      "com.twitter" %% "finagle-mysql" % twitterVersion,
+      "com.twitter" %% "finagle-stats" % twitterVersion,
+      "com.twitter" %% "twitter-server" % twitterVersion,
       "com.github.finagle" %% "finch-test" % finchVersion % Test,
-      "com.palantir.docker.compose" % "docker-compose-rule" % dockerComposeRuleVersion % Test,
+      "com.palantir.docker.compose" % "docker-compose-rule-junit4" % dockerComposeRuleVersion % Test,
       "junit" % "junit" % junitVersion % Test,
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test
     )

--- a/core/src/main/scala/jp/co/cyberagent/typebook/model/package.scala
+++ b/core/src/main/scala/jp/co/cyberagent/typebook/model/package.scala
@@ -35,7 +35,7 @@ import jp.co.cyberagent.typebook.version.SemanticVersion
 package object model {
   type Id = Long
 
-  implicit val jsonCodecConfig: Configuration = Configuration.default.withSnakeCaseKeys
+  implicit val jsonCodecConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
 
   implicit val subjectDecoder: Decoder[Subject] = deriveDecoder[Subject].map( subject => subject.description match {
     case Some(desc) if desc.isEmpty => subject.copy(description = None)

--- a/docker/docker-compose.db.yml
+++ b/docker/docker-compose.db.yml
@@ -2,9 +2,9 @@ version: '3'
 
 services:
   backend-db:
-    image: "mysql:5.7.19"
+    image: "mysql:5.7.21"
     healthcheck:
-      test: ["CMD", "mysql", "-e", "quit"]
+      test: ["CMD", "mysql", "-u", "typebook", "--password=typebook", "-e", "quit"]
       interval: "15s"
       timeout: "5s"
       retries: 5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3'
 
 services:
   backend-db:
-    image: "mysql:5.7.19"
+    image: "mysql:5.7.21"
     healthcheck:
-      test: ["CMD", "mysql", "-u", "typebook", "-p", "-e", "quit"]
+      test: ["CMD", "mysql", "-u", "typebook", "--password=typebook", "-e", "quit"]
       interval: "15s"
       timeout: "5s"
       retries: 5

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.1.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "4.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.4.1")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")

--- a/server/src/main/scala/jp/co/cyberagent/typebook/ServerApp.scala
+++ b/server/src/main/scala/jp/co/cyberagent/typebook/ServerApp.scala
@@ -35,20 +35,20 @@ object ServerApp extends TwitterServer with DefaultMySQLBackend {
   val conf = HttpServerConfig()
 
   lazy val httpServer: ListeningServer = Http.server
-    .configured(Http.Netty3Impl)
+    .configuredParams(Http.Http2)
     .withStatsReceiver(statsReceiver)
     .serve(s":${conf.listenPort}", RegistryService() )
 
   private def shutdown(): Unit = {
-    log.info("TypeBook is shutting down...")
+    info("TypeBook is shutting down...")
     Await.ready(httpServer.close())
   }
 
   def main(): Unit = {
-    log.info("Initializing Database...")
+    info("Initializing Database...")
     TableDefinition.initializeTables()
 
-    log.info("TypeBook is starting up...")
+    info("TypeBook is starting up...")
     onExit(shutdown())
     Await.ready(httpServer)
   }

--- a/server/src/main/scala/jp/co/cyberagent/typebook/api/SchemaService.scala
+++ b/server/src/main/scala/jp/co/cyberagent/typebook/api/SchemaService.scala
@@ -27,6 +27,7 @@ import com.twitter.logging.Logger
 import com.twitter.util.Future
 import io.finch._
 import io.finch.circe._
+import io.finch.syntax._
 import org.apache.avro.{Schema => AvroSchema}
 
 import jp.co.cyberagent.typebook.compatibility.{CompatibilityUtil, SchemaCompatibility}
@@ -37,9 +38,8 @@ import jp.co.cyberagent.typebook.version.{SemanticVersion, VersioningRule}
 
 
 object SchemaService extends SchemaServiceTrait with DefaultMySQLBackend {
-
-  def apply() = create :+: lookup :+: lookupAll :+: readById :+:
-                readByVersion :+: readVersions :+: checkCompatibility
+  val jsonEndpoints = create :+: lookup :+: lookupAll :+: readById :+:
+    readByVersion :+: readVersions :+: checkCompatibility
 }
 
 

--- a/server/src/main/scala/jp/co/cyberagent/typebook/db/MySQLBackend.scala
+++ b/server/src/main/scala/jp/co/cyberagent/typebook/db/MySQLBackend.scala
@@ -28,7 +28,7 @@ import scala.language.postfixOps
 import com.twitter.conversions.time._
 import com.twitter.finagle.{Mysql => TMysql}
 import com.twitter.finagle.client.DefaultPool
-import com.twitter.finagle.mysql.{Client, Cursors, Transactions}
+import com.twitter.finagle.mysql.{Client, Transactions}
 import io.circe._
 import io.circe.syntax._
 
@@ -37,12 +37,12 @@ import jp.co.cyberagent.typebook.config.BackendDbConfig
 
 object Mysql {
 
-  def default(): Client with Transactions with Cursors = {
+  def default(): Client with Transactions = {
     val conf = BackendDbConfig()
     standard(conf)
   }
 
-  def standard(conf: BackendDbConfig): Client with Transactions with Cursors = TMysql.client
+  def standard(conf: BackendDbConfig): Client with Transactions = TMysql.client
     .withCredentials(conf.user, conf.password.orNull)
     .withDatabase(conf.database)
     .configured(DefaultPool.Param(

--- a/server/src/test/scala/jp/co/cyberagent/typebook/ConfigServiceIntegrationSpec.scala
+++ b/server/src/test/scala/jp/co/cyberagent/typebook/ConfigServiceIntegrationSpec.scala
@@ -139,13 +139,10 @@ class ConfigServiceIntegrationSpec extends FlatSpec with StorageBackend with Sto
 
 
           // read a current compatibility value
-          val registryCompatibilityBuf1 = TestConfigService.readProperty(
+          val registryCompatibility1 = TestConfigService.readProperty(
             Input.get(s"/config/$subjectName/properties/compatibility")
           ).awaitValueUnsafe(awaitTime).get
 
-          buffer = new Array[Byte](registryCompatibilityBuf1.length)
-          registryCompatibilityBuf1.write(buffer, 0)
-          val registryCompatibility1 = new String(buffer)
           log.info(s"RegistryCompatibility1: $registryCompatibility1")
           registryCompatibility1 should equal("FULL")
 
@@ -159,13 +156,10 @@ class ConfigServiceIntegrationSpec extends FlatSpec with StorageBackend with Sto
 
 
           // read a current compatibility value
-          val registryCompatibilityBuf2 = TestConfigService.readProperty(
+          val registryCompatibility2 = TestConfigService.readProperty(
             Input.get(s"/config/$subjectName/properties/compatibility")
           ).awaitValueUnsafe(awaitTime).get
 
-          buffer = new Array[Byte](registryCompatibilityBuf2.length)
-          registryCompatibilityBuf2.write(buffer, 0)
-          val registryCompatibility2 = new String(buffer)
           log.info(s"RegistryCompatibility2: $registryCompatibility2")
           registryCompatibility2 should equal("BACKWARD")
 
@@ -179,13 +173,10 @@ class ConfigServiceIntegrationSpec extends FlatSpec with StorageBackend with Sto
 
 
           // read a current compatibility value
-          val registryCompatibilityBuf3 = TestConfigService.readProperty(
+          val registryCompatibility3 = TestConfigService.readProperty(
             Input.get(s"/config/$subjectName/properties/compatibility")
           ).awaitValueUnsafe(awaitTime).get
 
-          buffer = new Array[Byte](registryCompatibilityBuf3.length)
-          registryCompatibilityBuf3.write(buffer, 0)
-          val registryCompatibility3 = new String(buffer)
           log.info(s"RegistryCompatibility3: $registryCompatibility3")
           registryCompatibility3 should equal("FORWARD")
 
@@ -198,13 +189,10 @@ class ConfigServiceIntegrationSpec extends FlatSpec with StorageBackend with Sto
           updatedRows4 should equal(1L)
 
           // read a current compatibility value
-          val registryCompatibilityBuf4 = TestConfigService.readProperty(
+          val registryCompatibility4 = TestConfigService.readProperty(
             Input.get(s"/config/$subjectName/properties/compatibility")
           ).awaitValueUnsafe(awaitTime).get
 
-          buffer = new Array[Byte](registryCompatibilityBuf4.length)
-          registryCompatibilityBuf4.write(buffer, 0)
-          val registryCompatibility4 = new String(buffer)
           log.info(s"RegistryCompatibility4: $registryCompatibility4")
           registryCompatibility4 should equal("NONE")
 
@@ -257,12 +245,10 @@ class ConfigServiceIntegrationSpec extends FlatSpec with StorageBackend with Sto
           log.info(s"default config for subject $subjectName is $actual")
           actual should equal (RegistryConfig.default)
 
-          val actualPropBuf = TestConfigService.readProperty(
+          val actualProp = TestConfigService.readProperty(
             Input.get(s"/config/$subjectName/properties/${RegistryConfig.Compatibility}")
           ).awaitValueUnsafe(awaitTime).get
-          buffer = new Array[Byte](actualPropBuf.length)
-          actualPropBuf.write(buffer, 0)
-          val actualProp = new String(buffer)
+
           log.info(s"default compatibility value for subject $subjectName is $actualProp")
           actualProp should equal (RegistryConfig.default.compatibility.toString)
         }

--- a/server/src/test/scala/jp/co/cyberagent/typebook/RestClientUtil.scala
+++ b/server/src/test/scala/jp/co/cyberagent/typebook/RestClientUtil.scala
@@ -2,13 +2,13 @@ package jp.co.cyberagent.typebook
 
 import scala.language.postfixOps
 
-import com.palantir.docker.compose.DockerComposition
+import com.palantir.docker.compose.DockerComposeRule
 import com.twitter.conversions.time._
 import com.twitter.finagle.{Http, Service}
 import com.twitter.finagle.http.{Request, Response}
 
 trait RestClientUtil { self: SchemaRegistryBackend =>
-  def withRestClient(dc: DockerComposition, label: String, tries: Int = 15)(proc: Service[Request, Response] => Any): Any = {
+  def withRestClient(dc: DockerComposeRule, label: String, tries: Int = 15)(proc: Service[Request, Response] => Any): Any = {
     val client = WaitUntilAvailable(tries) andThen Http.client.newService(getServerEndpoint(dc), label)
     proc(client)
     client.close(30 seconds)

--- a/server/src/test/scala/jp/co/cyberagent/typebook/StorageBackend.scala
+++ b/server/src/test/scala/jp/co/cyberagent/typebook/StorageBackend.scala
@@ -2,20 +2,20 @@ package jp.co.cyberagent.typebook
 
 import scala.language.postfixOps
 
-import com.palantir.docker.compose.DockerComposition
+import com.palantir.docker.compose.{DockerComposeRule, ImmutableDockerComposeRule}
 import com.palantir.docker.compose.connection.waiting.HealthChecks
 import org.scalatest.concurrent.Eventually
 
 trait StorageBackend extends RuleFixture with Eventually with Logging {
 
-  def dockerComposition(logDir: String): DockerComposition = DockerComposition
-    .of("docker/docker-compose.db.yml")
+  def dockerComposition(logDir: String): ImmutableDockerComposeRule = DockerComposeRule.builder()
+    .file("docker/docker-compose.db.yml")
     .waitingForService("backend-db", HealthChecks.toHaveAllPortsOpen)
     .saveLogsTo(s"target/dockerLogs/$logDir")
     .build()
 
-  def getStorageHostPort(dc: DockerComposition): String = {
-    val port = dc.portOnContainerWithInternalMapping("backend-db", 3306)
+  def getStorageHostPort(dc: DockerComposeRule): String = {
+    val port = dc.containers().container("backend-db").port(3306)
     s"${port.getIp}:${port.getExternalPort}"
   }
 

--- a/server/src/test/scala/jp/co/cyberagent/typebook/StorageClientUtil.scala
+++ b/server/src/test/scala/jp/co/cyberagent/typebook/StorageClientUtil.scala
@@ -2,7 +2,7 @@ package jp.co.cyberagent.typebook
 
 import scala.language.postfixOps
 
-import com.palantir.docker.compose.DockerComposition
+import com.palantir.docker.compose.DockerComposeRule
 import com.twitter.finagle.{Mysql => TMysql}
 import com.twitter.finagle.mysql.{QueryRequest, Client => MysqlClient}
 import com.twitter.util.{Await, Stopwatch}
@@ -28,7 +28,7 @@ trait StorageClientUtil { self: StorageBackend =>
   }
 
   // Create MySQL Client and wait until database is available
-  def withDbClient(dc: DockerComposition, tries: Int = 10)(proc: MysqlClient => Any): Any = {
+  def withDbClient(dc: DockerComposeRule, tries: Int = 10)(proc: MysqlClient => Any): Any = {
     val conf = BackendDbConfig(getStorageHostPort(dc))
     waitUntilDbBecomesAvailable(conf, tries)
     val client = Mysql.standard(conf)

--- a/server/src/test/scala/jp/co/cyberagent/typebook/SubjectServiceIntegrationSpec.scala
+++ b/server/src/test/scala/jp/co/cyberagent/typebook/SubjectServiceIntegrationSpec.scala
@@ -64,22 +64,18 @@ class SubjectServiceIntegrationSpec extends FlatSpec with StorageBackend with St
 
 
           // read a specific field
-          val nameBuf = TestSubjectService.readField(
+          val name = TestSubjectService.readField(
             Input.get(s"/subjects/$subjectName", ("field", "name"))
           ).awaitValueUnsafe(awaitTime).get
-          buffer = new Array[Byte](nameBuf.length)
-          nameBuf.write(buffer, 0)
-          val name = new String(buffer)
+
           log.info(s"name is $name")
           name should equal (subjectName)
 
 
-          val descriptionBuf = TestSubjectService.readField(
+          val description = TestSubjectService.readField(
             Input.get(s"/subjects/$subjectName", ("field", "description"))
           ).awaitValueUnsafe(awaitTime).get
-          buffer = new Array[Byte](descriptionBuf.length)
-          descriptionBuf.write(buffer, 0)
-          val description = new String(buffer)
+
           log.info(s"description is $description")
           description should equal (subjectDescription)
         }


### PR DESCRIPTION
- upgrade dependent libraries and adjusting to the new API
    - docker-compose-rule: 0.16 -> 0.33
    - finch: 0.15.1 => 0.17
      - use type-level Content-Type notation [finch#794](https://github.com/finagle/finch/pull/794)
    - Finagle: 6.45.0 => 18.02.0 
      - Use Netty4Impl rather than Netty3Impl
      - HTTP/2 support
  